### PR TITLE
use buffer on response in clientDoDeadline

### DIFF
--- a/client.go
+++ b/client.go
@@ -918,6 +918,7 @@ func clientDoDeadline(req *Request, resp *Response, deadline time.Time, c client
 	req.copyToSkipBody(reqCopy)
 	swapRequestBody(req, reqCopy)
 	respCopy := AcquireResponse()
+	swapResponseBody(resp, respCopy)
 
 	// Note that the request continues execution on ErrTimeout until
 	// client-specific ReadTimeout exceeds. This helps limiting load
@@ -936,8 +937,8 @@ func clientDoDeadline(req *Request, resp *Response, deadline time.Time, c client
 	case err = <-ch:
 		if resp != nil {
 			respCopy.copyToSkipBody(resp)
-			swapResponseBody(resp, respCopy)
 		}
+		swapResponseBody(resp, respCopy)
 		swapRequestBody(reqCopy, req)
 		ReleaseResponse(respCopy)
 		ReleaseRequest(reqCopy)


### PR DESCRIPTION
we want to do this so that we can reuse the response's existing buffer
rather than allocating new ones. allocating memory is expensive