### PR TITLE
make it so .Do() can also follow redirects

### DIFF
--- a/client.go
+++ b/client.go
@@ -296,8 +296,6 @@ func (c *Client) Post(dst []byte, url string, postArgs *Args) (statusCode int, b
 //   - from RequestURI if it contains full url with scheme and host;
 //   - from Host header otherwise.
 //
-// The function doesn't follow redirects. Use Get* for following redirects.
-//
 // Response is ignored if resp is nil.
 //
 // ErrTimeout is returned if the response wasn't returned during
@@ -322,8 +320,6 @@ func (c *Client) DoTimeout(req *Request, resp *Response, timeout time.Duration) 
 //
 //   - from RequestURI if it contains full url with scheme and host;
 //   - from Host header otherwise.
-//
-// The function doesn't follow redirects. Use Get* for following redirects.
 //
 // Response is ignored if resp is nil.
 //
@@ -350,8 +346,6 @@ func (c *Client) DoDeadline(req *Request, resp *Response, deadline time.Time) er
 //   - from Host header otherwise.
 //
 // Response is ignored if resp is nil.
-//
-// The function doesn't follow redirects. Use Get* for following redirects.
 //
 // ErrNoFreeConns is returned if all Client.MaxConnsPerHost connections
 // to the requested host are busy.

--- a/client.go
+++ b/client.go
@@ -380,6 +380,7 @@ func (c *Client) Do(req *Request, resp *Response) error {
 			break
 		}
 		url = getRedirectURL(url, location)
+		resp.Header.VisitAllCookie(req.Header.SetCookieBytesKV)
 	}
 
 	return err

--- a/http.go
+++ b/http.go
@@ -45,6 +45,8 @@ type Request struct {
 
 	isTLS bool
 
+	// MaxFollowRedirects sets the number of times .Do() should
+	// follow redirects
 	MaxFollowRedirects int
 }
 

--- a/http.go
+++ b/http.go
@@ -44,6 +44,8 @@ type Request struct {
 	keepBodyBuffer bool
 
 	isTLS bool
+
+	MaxFollowRedirects int
 }
 
 // Response represents HTTP response.
@@ -816,6 +818,7 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 // Reset clears request contents.
 func (req *Request) Reset() {
 	req.Header.Reset()
+	req.MaxFollowRedirects = 0
 	req.resetSkipHeader()
 }
 


### PR DESCRIPTION
this passes tests so i believe it is still working with the .Get()
family of functions. which leads me to believe it also will now work
with .Do(), given that they share a code path