### PR TITLE
make MaxFollowRedirects part of Client, not Request

### DIFF
--- a/http.go
+++ b/http.go
@@ -44,10 +44,6 @@ type Request struct {
 	keepBodyBuffer bool
 
 	isTLS bool
-
-	// MaxFollowRedirects sets the number of times .Do() should
-	// follow redirects
-	MaxFollowRedirects int
 }
 
 // Response represents HTTP response.
@@ -820,7 +816,6 @@ func readMultipartForm(r io.Reader, boundary string, size, maxInMemoryFileSize i
 // Reset clears request contents.
 func (req *Request) Reset() {
 	req.Header.Reset()
-	req.MaxFollowRedirects = 0
 	req.resetSkipHeader()
 }
 


### PR DESCRIPTION
this is a more sensible place for it. also request gets reset in the
middle of the fetch cycle so it isn't stable